### PR TITLE
Fork of tap-github, update to tap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(name='tap-github',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_github'],
       install_requires=[
-          'singer-python==5.3.3',
+          # 'singer-python @ git+https://github.com/BenjMaq/singer-python@bump_pytz_version',
+          'singer-python==5.12.0',
           'requests==2.20.0'
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(name='tap-github',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_github'],
       install_requires=[
-          # 'singer-python @ git+https://github.com/BenjMaq/singer-python@bump_pytz_version',
           'singer-python==5.12.0',
           'requests==2.20.0'
       ],


### PR DESCRIPTION
A few updates:
- Enable passing a Github Enterprise endpoint in config using `api_endpoint`, instead of relying on the public endpoint
- Update to python syntax
- Enable fetching repos and organizations dynamically:
    - If `repository` is specified in config, the tap will only fetch this specific repo
    - If `organization` is specified in config, the tap will fetch all repo's from this organization
    - If neither `repository` nor `organization` is specified in config, the tap will fetch all repo's from all organizations available
